### PR TITLE
Don't set C and CXX compiler if CMAKE_TOOLCHAIN_FILE property is defined

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,9 @@ impl Config {
                 //
                 // Also don't specify this on Windows as it's not needed for
                 // MSVC and for MinGW it doesn't really vary.
-                if !self.defined(&tool_var) && env::consts::FAMILY != "windows" {
+                if !self.defined("CMAKE_TOOLCHAIN_FILE")
+                   && !self.defined(&tool_var)
+                   && env::consts::FAMILY != "windows" {
                     let mut ccompiler = OsString::from("-D");
                     ccompiler.push(&tool_var);
                     ccompiler.push("=");


### PR DESCRIPTION
Setting the C and CXX compilers causes problems when using a CMAKE_TOOLCHAIN_FILE for cross-compiling.  This PR conservatively blocks those flags but still allows cmake-rs' default compile flags to be set for Rust compatibility..