### PR TITLE
Allow specifying a CMAKE_TOOLCHAIN_FILE in the environment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,6 +347,12 @@ impl Config {
             cmd.arg(&format!("-DCMAKE_BUILD_TYPE={}", profile));
         }
 
+        if !self.defined("CMAKE_TOOLCHAIN_FILE") {
+            if let Ok(s) = env::var("CMAKE_TOOLCHAIN_FILE") {
+                cmd.arg(&format!("-DCMAKE_TOOLCHAIN_FILE={}", s));
+            }
+        }
+
         run(cmd.env("CMAKE_PREFIX_PATH", cmake_prefix_path), "cmake");
 
         let mut parallel_args = Vec::new();


### PR DESCRIPTION
For cross-compiling scenarios it's often necessary to pass
CMAKE_TOOLCHAIN_FILE to cmake. In a large project like Servo
there might be a lot of cmake-using dependencies that will all
need to pass it, so pulling this from an environment variable
will let people doing cross-compiles specify this just once.