### PR TITLE
Don't pass through `CARGO_MAKEFLAGS` args on BSD platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,10 +495,17 @@ impl Config {
 				}
                 _ if fs::metadata(&dst.join("build/Makefile")).is_ok() => {
                     match env::var_os("CARGO_MAKEFLAGS") {
-                        // Only do this on non-windows as we could actually be
-                        // invoking make instead of mingw32-make which doesn't
-                        // work with our jobserver
-                        Some(ref s) if !cfg!(windows) => makeflags = Some(s.clone()),
+                        // Only do this on non-windows and non-bsd
+                        // On Windows, we could be invoking make instead of
+                        // mingw32-make which doesn't work with our jobserver
+                        // bsdmake also does not work with our job server
+                        Some(ref s) if !(cfg!(windows) ||
+                                         cfg!(target_os = "openbsd") ||
+                                         cfg!(target_os = "netbsd") ||
+                                         cfg!(target_os = "freebsd") ||
+                                         cfg!(target_os = "bitrig") ||
+                                         cfg!(target_os = "dragonflybsd")
+                        ) => makeflags = Some(s.clone()),
 
                         // This looks like `make`, let's hope it understands `-jN`.
                         _ => parallel_args.push(format!("-j{}", s)),


### PR DESCRIPTION
These are incompatible with bsdmake, and will cause failures in
any packages that use this lib on systems where make == bsdmake.

Tested on OpenBSD 6.2/amd64 against `git2-rs`. This fixed all build failures on that platform.

Another possible solution is forcing bsd platforms to use `gmake`, but this introduces an external dependency and is otherwise unnecessary because `cmake` generates portable `Makefile`s