### PR TITLE
Properly format DEP_XXX_ROOT

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,7 @@ impl Config {
         // Add all our dependencies to our cmake paths
         let mut cmake_prefix_path = Vec::new();
         for dep in &self.deps {
+            let dep = dep.to_uppercase().replace('-', "_");
             if let Some(root) = env::var_os(&format!("DEP_{}_ROOT", dep)) {
                 cmake_prefix_path.push(PathBuf::from(root));
             }


### PR DESCRIPTION
When specifying a dependency on library "foo-bar" by calling `Config::register_dep`, the environment variable to read when setting `CMAKE_PREFIX_PATH` is `DEP_FOO_BAR_ROOT`. The previous version of `register_dep` would work only if passed "FOO_BAR". With this change, it also accepts the more natural library name, i.e. "foo-bar", and does the necessary formatting internally when deriving the environment variable name.