### PR TITLE
fix incorrect message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,8 +517,9 @@ impl Config {
         }
 
         if self.always_configure || !build.join("CMakeCache.txt").exists() {
-            println!("CMake project was already configured. Skipping configuration step.");
             run(cmd.env("CMAKE_PREFIX_PATH", cmake_prefix_path), "cmake");
+        } else {
+            println!("CMake project was already configured. Skipping configuration step.");
         }
 
         let mut makeflags = None;


### PR DESCRIPTION
This message was extremely confusing because it was incorrect twice:

* if `CMakeCache` does not exist, then the project was not previously configured, 
* in the branch where the message was printed, the project was configured right afterwards, so the configuration step was not skipped, it was always performed.

This was doubly confusing while debugging. 

I think this whole skipping logic is bogus anyways. If `::build` is being called is because we want to build the project. When does that happen? Very likely in a build script. When are build scripts run ? Well, if people are using them properly, when either the build script changes, or some other file, critical to the build process, changes. So if the build script changed, the configuration files might have changed, which means that we want to reconfigure the project. 

What are the supposed advantages of skipping the configuration step? AFAIK if cmake is invoked with the exact same flags and environment variables twice, the second time this becomes a no-op, that is, cmake detects that and skips the configuration step. So I don't know why we should try to do that here as well. 

Anyways, somebody found this useful, so that should be fixed in a different PR, maybe after discussing it in an issue. 