### PR TITLE
msvc: pass -Thost=x64 when compiling x64 target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,6 +394,9 @@ impl Config {
             if self.generator.is_none() {
                 cmd.arg("-G").arg(self.visual_studio_generator(&target));
             }
+            if target.contains("x86_64") {
+                cmd.arg("-Thost=x64");
+            }
         } else if target.contains("redox") {
             if !self.defined("CMAKE_SYSTEM_NAME") {
                 cmd.arg("-DCMAKE_SYSTEM_NAME=Generic");


### PR DESCRIPTION
If you try to build rust for `--host x86_64-pc-windows-msvc`, you will receive the following error when it tries to compile llvm:
```
Visual Studio generators use the x86 host compiler by
default, even for 64-bit targets. This can result in linker
instability and out of memory errors. To use the 64-bit
host compiler, pass -Thost=x64 on the CMake command line.
```
This change passes `-Thost=x64` to cmake when compiling for x64, which eliminates the error.