### PR TITLE
Fix argument order so that the source path is always the last argument.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,8 +342,8 @@ impl Config {
             cmd.arg("--debug-output");
         }
 
-        cmd.arg(&self.path)
-           .current_dir(&build);
+        cmd.current_dir(&build);
+
         if target.contains("windows-gnu") {
             if host.contains("windows") {
                 // On MinGW we need to coerce cmake to not generate a visual
@@ -606,7 +606,7 @@ impl Config {
         }
 
         if self.always_configure || !build.join("CMakeCache.txt").exists() {
-            run(cmd.env("CMAKE_PREFIX_PATH", cmake_prefix_path), "cmake");
+            run(cmd.env("CMAKE_PREFIX_PATH", cmake_prefix_path), "cmake", &self.path);
         } else {
             println!("CMake project was already configured. Skipping configuration step.");
         }
@@ -666,7 +666,7 @@ impl Config {
             .args(&parallel_args)
             .current_dir(&build);
 
-        run(&mut cmd, "cmake");
+        run(&mut cmd, "cmake", &self.path);
 
         println!("cargo:root={}", dst.display());
         return dst
@@ -743,7 +743,10 @@ impl Config {
     }
 }
 
-fn run(cmd: &mut Command, program: &str) {
+fn run(cmd: &mut Command, program: &str, src_dir: &PathBuf) {
+    // The path to the source dir should always be the last arg
+    cmd.arg(src_dir);
+
     println!("running: {:?}", cmd);
     let status = match cmd.status() {
         Ok(status) => status,


### PR DESCRIPTION
Cmake expects the source path to be listed *after* the flags. Failing to do so can cause the build to fail with a confusing error message.

### Steps to reproduce:
Checkout [ssh2-rs](https://github.com/alexcrichton/ssh2-rs.git) and run `cargo build`. This fails for me (with Cmake 3.12.1 installed) with:
```
   Compiling libssh2-sys v0.2.10 (file:///home/reuben/scratch/ssh2-rs/libssh2-sys)
error: failed to run custom build command for `libssh2-sys v0.2.10 (file:///home/reuben/scratch/ssh2-rs/libssh2-sys)`
process didn't exit successfully: `/home/reuben/scratch/ssh2-rs/target/debug/build/libssh2-sys-a26e2330a22c7e9a/build-script-build` (exit code: 101)
--- stdout
running: "cmake" "/home/reuben/scratch/ssh2-rs/libssh2-sys/libssh2" "-DCRYPTO_BACKEND=OpenSSL" "-DENABLE_ZLIB_COMPRESSION=OFF" "-DBUILD_SHARED_LIBS=OFF" "-DCMAKE_INSTALL_LIBDIR=lib" "-DBUILD_EXAMPLES=OFF" "-DBUILD_TESTING=OFF" "-DCMAKE_INSTALL_PREFIX=/home/reuben/scratch/ssh2-rs/target/debug/build/libssh2-sys-8292bca816154811/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/x86_64-pc-linux-gnu/gcc-bin/6.4.0/c++" "-DCMAKE_BUILD_TYPE=Debug"

--- stderr
CMake Error: The source directory "/home/reuben/scratch/ssh2-rs/target/debug/build/libssh2-sys-8292bca816154811/out/build/-m64" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
thread 'main' panicked at '
command did not execute successfully, got: exit code: 1

build script failed, must exit now', /home/reuben/.cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.33/src/lib.rs:773:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

I've tested the fix with the above package and it works as expected.