### PR TITLE
enable toolset spec only if NMake generator is not selected

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,10 +406,14 @@ impl Config {
             // If we're on MSVC we need to be sure to use the right generator or
             // otherwise we won't get 32/64 bit correct automatically.
             // This also guarantees that NMake generator isn't chosen implicitly.
+            let using_nmake_generator;
             if self.generator.is_none() {
                 cmd.arg("-G").arg(self.visual_studio_generator(&target));
+                using_nmake_generator = false;
+            } else {
+                using_nmake_generator = self.generator.as_ref().unwrap() == "NMake Makefiles";
             }
-            if target.contains("x86_64") && !is_ninja {
+            if target.contains("x86_64") && !is_ninja && !using_nmake_generator {
                 cmd.arg("-Thost=x64");
             }
         } else if target.contains("redox") {


### PR DESCRIPTION
On Windows with MSVC, if we use both generator `-G NMake Makefiles` and some tool specifier, e.g. `-Thost=x64` then cmake will complain:

```
Generator

    NMake Makefiles

  does not support toolset specification, but toolset

    host=x64

  was specified.
```

So this PR just tries to enable the toolset only if the generator is not `NMake Makefiles`.

Many thanks for any comment.