### PR TITLE
Add parallel flags after --

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,10 +681,6 @@ impl Config {
             cmd.env("MAKEFLAGS", flags);
         }
 
-        if let Some(flags) = parallel_flags {
-            cmd.arg(flags);
-        }
-
         cmd.arg("--build").arg(".");
 
         if !self.no_build_target {
@@ -696,6 +692,10 @@ impl Config {
             .arg("--")
             .args(&self.build_args)
             .current_dir(&build);
+
+        if let Some(flags) = parallel_flags {
+            cmd.arg(flags);
+        }
 
         run(&mut cmd, "cmake");
 


### PR DESCRIPTION
I dont fully understand whats going on here, but I can see in https://github.com/alexcrichton/cmake-rs/commit/8c11170a0ced05d2c0131dc7388af7621083107d the parallel flags are moved before the `--` which doesn't seem intentional.
Changing the order back resolves the issue in shaderc-rs.

A new release immediately after this is merged is needed.

closes https://github.com/alexcrichton/cmake-rs/issues/72