### PR TITLE
add support for thumbv7a-pc-windows-msvc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,6 +417,9 @@ impl Config {
                 if target.contains("x86_64") {
                     cmd.arg("-Thost=x64");
                     cmd.arg("-Ax64");
+                } else if target.contains("thumbv7a") {
+                    cmd.arg("-Thost=x64");
+                    cmd.arg("-Aarm");
                 } else if target.contains("i686") {
                     use cc::windows_registry::{find_vs_version, VsVers};
                     match find_vs_version() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,7 +734,7 @@ impl Config {
             ),
             Err(msg) => panic!(msg),
         };
-        if target.contains("i686") || target.contains("x86_64") {
+        if target.contains("i686") || target.contains("x86_64") || target.contains("thumbv7a") {
             base.to_string()
         } else {
             panic!("unsupported msvc target: {}", target);


### PR DESCRIPTION
Hello

This is Chandler from Microsoft working on enabling ARM32 for Azure IoTEdge, which has a module is written in rust, we have already enabled ARM32 in rust tool chain (https://github.com/rust-lang/rust/pull/53621), although there is some missing dependency in LLVM so ARM is not officially supported yet in official release, we're using a private version of cargo and rustc to compile Azure IoTEdge in ARM already, check out https://github.com/Azure/iotedge/blob/master/edgelet/build/windows/build.ps1#L30. Besides addressing ARM in rust, we also need to update a few crates to support ARM, e.g. backtrace-rs, winapi, cmake-rs, etc.. 

This is a simple change inside function visual_studio_generator to unblock this new build string. Please take a look.

Thanks
Chandler