### PR TITLE
Add support for arm64 Windows targets.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,9 @@ impl Config {
                 } else if target.contains("thumbv7a") {
                     cmd.arg("-Thost=x64");
                     cmd.arg("-Aarm");
+                } else if target.contains("aarch64") {
+                    cmd.arg("-Thost=x64");
+                    cmd.arg("-AARM64");
                 } else if target.contains("i686") {
                     use cc::windows_registry::{find_vs_version, VsVers};
                     match find_vs_version() {
@@ -737,7 +740,7 @@ impl Config {
             ),
             Err(msg) => panic!(msg),
         };
-        if target.contains("i686") || target.contains("x86_64") || target.contains("thumbv7a") {
+        if ["i686", "x86_64", "thumbv7a", "aarch64"].iter().any(|t| target.contains(t)) {
             base.to_string()
         } else {
             panic!("unsupported msvc target: {}", target);


### PR DESCRIPTION
This is necessary to support a Windows arm64 build of Servo.