### PR TITLE
Support for ASM_FLAGS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,25 +341,13 @@ impl Config {
         if !ndk {
             cxx_cfg.target(&target);
         }
-        let mut asm_cfg = cc::Build::new();
-        asm_cfg
-            .cargo_metadata(false)
-            .opt_level(0)
-            .debug(false)
-            .warnings(false)
-            .host(&host)
-            .no_default_flags(ndk);
-        if !ndk {
-            asm_cfg.target(&target);
-        }
         if let Some(static_crt) = self.static_crt {
             c_cfg.static_crt(static_crt);
             cxx_cfg.static_crt(static_crt);
-            asm_cfg.static_crt(static_crt);
         }
         let c_compiler = c_cfg.get_compiler();
         let cxx_compiler = cxx_cfg.get_compiler();
-        let asm_compiler = asm_cfg.get_compiler();
+        let asm_compiler = c_cfg.get_compiler();
 
         let dst = self
             .out_dir


### PR DESCRIPTION
This PR adds support for `ASM_FLAGS` environment variable being passed to invocations of cmake. This both allows default ASM flags to be provided internally by `cc-rs` and allows extra flags to be provided by the user via `Config.asmflag()`. This is important if the cmake project under question includes any ASM files (such as [boringssl](https://github.com/google/boringssl/blob/3a3552247ecb0bfb260a36d9da7a3bce7fdc3f8a/crypto/curve25519/asm/x25519-asm-arm.S), which is vendored by [grpc-rs](https://github.com/pingcap/grpc-rs/blob/019e1767d1c8317344987e05ee6876efa6f26c6f/grpc-sys/build.rs)).

The implementation here is mostly just a copy-paste of the c/c++ equivalents found in `src/lib.rs`, so if there's a different approach you'd prefer, please let me know.