### PR TITLE
Fix cross-compiling ios targets with cmake 3.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ categories = ["development-tools::build-utils"]
 
 [dependencies]
 cc = "1.0.41"
+lazy_static = "1.0"
+regex = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ impl Config {
     /// This will run both the build system generator command as well as the
     /// command to build the library.
     pub fn build(&mut self) -> PathBuf {
-        let target = match self.target.clone() {
+        let target_triple = match self.target.clone() {
             Some(t) => t,
             None => {
                 let mut t = getenv_unwrap("TARGET");
@@ -316,7 +316,7 @@ impl Config {
             }
         };
         let host = self.host.clone().unwrap_or_else(|| getenv_unwrap("HOST"));
-        let msvc = target.contains("msvc");
+        let msvc = target_triple.contains("msvc");
         let ndk = self.uses_android_ndk();
         let mut c_cfg = cc::Build::new();
         c_cfg
@@ -327,7 +327,7 @@ impl Config {
             .host(&host)
             .no_default_flags(ndk);
         if !ndk {
-            c_cfg.target(&target);
+            c_cfg.target(&target_triple);
         }
         let mut cxx_cfg = cc::Build::new();
         cxx_cfg
@@ -339,7 +339,7 @@ impl Config {
             .host(&host)
             .no_default_flags(ndk);
         if !ndk {
-            cxx_cfg.target(&target);
+            cxx_cfg.target(&target_triple);
         }
         if let Some(static_crt) = self.static_crt {
             c_cfg.static_crt(static_crt);
@@ -383,7 +383,7 @@ impl Config {
         if let Some(ref generator) = self.generator {
             is_ninja = generator.to_string_lossy().contains("Ninja");
         }
-        if target.contains("windows-gnu") {
+        if target_triple.contains("windows-gnu") {
             if host.contains("windows") {
                 // On MinGW we need to coerce cmake to not generate a visual
                 // studio build system but instead use makefiles that MinGW can
@@ -440,22 +440,23 @@ impl Config {
             // This also guarantees that NMake generator isn't chosen implicitly.
             let using_nmake_generator;
             if self.generator.is_none() {
-                cmd.arg("-G").arg(self.visual_studio_generator(&target));
+                cmd.arg("-G")
+                    .arg(self.visual_studio_generator(&target_triple));
                 using_nmake_generator = false;
             } else {
                 using_nmake_generator = self.generator.as_ref().unwrap() == "NMake Makefiles";
             }
             if !is_ninja && !using_nmake_generator {
-                if target.contains("x86_64") {
+                if target_triple.contains("x86_64") {
                     cmd.arg("-Thost=x64");
                     cmd.arg("-Ax64");
-                } else if target.contains("thumbv7a") {
+                } else if target_triple.contains("thumbv7a") {
                     cmd.arg("-Thost=x64");
                     cmd.arg("-Aarm");
-                } else if target.contains("aarch64") {
+                } else if target_triple.contains("aarch64") {
                     cmd.arg("-Thost=x64");
                     cmd.arg("-AARM64");
-                } else if target.contains("i686") {
+                } else if target_triple.contains("i686") {
                     use cc::windows_registry::{find_vs_version, VsVers};
                     match find_vs_version() {
                         Ok(VsVers::Vs16) => {
@@ -468,14 +469,14 @@ impl Config {
                         _ => {}
                     };
                 } else {
-                    panic!("unsupported msvc target: {}", target);
+                    panic!("unsupported msvc target: {}", target_triple);
                 }
             }
-        } else if target.contains("redox") {
+        } else if target_triple.contains("redox") {
             if !self.defined("CMAKE_SYSTEM_NAME") {
                 cmd.arg("-DCMAKE_SYSTEM_NAME=Generic");
             }
-        } else if target.contains("solaris") {
+        } else if target_triple.contains("solaris") {
             if !self.defined("CMAKE_SYSTEM_NAME") {
                 cmd.arg("-DCMAKE_SYSTEM_NAME=SunOS");
             }


### PR DESCRIPTION
## Summary

This PR fixes iOS cross-compilation support when using Cmake 3.14+. The issue is described in more detail here: https://github.com/alexcrichton/cmake-rs/issues/87

## Implementation

This PR checks the target triplet (either the `target` member variable if it's set, otherwise the `TARGET` environment variable) and looks for an ending of `-apple-ios` to determine if we're cross-compiling for iOS or not.

If we are cross-compiling for iOS, it disables the default compiler flags for the cc-rs build config, and proceeds to set the required flags to allow cmake itself to set them:
* If `CMAKE_SYSTEM_NAME` is not set, set it to `iOS`.
* If `CMAKE_OSX_ARCHITECTURES` is not set, set it to the cmake equivalent of the target architecture pulled from the `target` variable. (cmake equivalents are: `arm64`, `armv7`, `armv7s`, `i386`, or `x86_64`)
* If `CMAKE_OSX_DEPLOYMENT_TARGET` is not set, we look for the `IPHONEOS_DEPLOYMENT_TARGET` environment variable (which is what cc-rs, llvm, rustc, etc use). If that doesn't exist, we default to `7.0`, which is what cc-rs defaults to (note that cmake defaults to 9.0, but in my opinion, it's better to have consistency across the whole project than to have vertical consistency within a particular tool).
* If `CMAKE_OSX_SYSROOT` isn't set, set it to either `iphoneos` or `iphonesimulator` to match the (canonical, version-less) sdk name xcode uses (`xcodebuild -showsdks`). This could also be set to a path to an SDK, but by setting it to the name of an SDK, cmake automatically selects the path to the most recent version it can find for that sdk.

I set the variables up so that it only sets them if they weren't previously defined, which should allow users to override them however they want.

`-fPIC` and `-fembed-bitcode` are added, as those were previously added by cc-rs (which we disabled, as noted above) but are not currently added by cmake. (I couldn't find documentation stating whether `-fPIC` is necessary, but I've left it in for continuity)

(I only have minimal rust experience at the moment, so if there are any conventions you'd like me to follow that I might not know about, feel free to suggest.)

## Questions

### Cmake <3.14

One caveat is that I've only tested this with cmake 3.15. I'm assuming it works with cmake 3.14 since the code in question within cmake hasn't changed. However, I don't know how it handles cmake <3.14.

Prior to cmake 3.14, I believe the procedure was to set `CMAKE_OSX_SYSROOT` (same as above) and `CMAKE_OSX_SYSROOT` (same as above). `CMAKE_SYSTEM_NAME` will be set to `Darwin` automatically within cmake.

I'm not sure 100% how cmake <3.14 handled `CMAKE_OSX_DEPLOYMENT_TARGET`/`IPHONEOS_DEPLOYMENT_TARGET` so I can't speak to that.

Do you want cmake-rs to support versions <3.14? If so we will need a way to determine which cmake version is installed. An easier middle option would be to have the above variables set only for 3.14+ and do nothing for versions <3.14, which in theory might facilitate backwards compatibility with existing projects using cmake-rs.

I don't currently have a good understanding of the needs of cmake-rs and the community using it, so I leave that up to your discretion. How do you want to handle introducing this feature?

### Config variables

Do you want the `deploymentTarget` to be a `Config` variable? Practically speaking, it can currently be set by defining the cmake variable `CMAKE_OSX_DEPLOYMENT_TARGET`. (Although, I imagine deployment target might be a configuration option that other targets might have, which is why I mention `deploymentTarget` instead of `osxDeploymentTarget` or `iosDeploymentTarget`.)

This gets a bit hairy though because `CMAKE_OSX_DEPLOYMENT_TARGET` is also the variable for setting the macOS deployment target when building for a macOS target. Cmake automatically sets `CMAKE_OSX_DEPLOYMENT_TARGET` from `MACOSX_DEPLOYMENT_TARGET` when `CMAKE_SYSTEM_NAME` is set to `Darwin` but not when it's set to `iOS`.

My point is mainly just that a) if environment variables for the deployment target are namespaced per platform, it could suggest that if a cmake-rs `Config` parameter were to be added, it might want to do the same. And b) I could see a future where cmake adds support for `CMAKE_OSX_DEPLOYMENT_TARGET` defaulting to `IPHONEOS_DEPLOYMENT_TARGET`, in which case using environment variables as the canonical way to set the deployment target might be the way to go anyways, rather than a `Config` variable (with the added benefit that it takes cmake-rs out of the loop).