### PR TITLE
Add PIC option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub struct Config {
     no_build_target: bool,
     verbose_cmake: bool,
     verbose_make: bool,
-    pic: Option<bool>
+    pic: Option<bool>,
 }
 
 /// Builds the native library rooted at `path` with the default cmake options.
@@ -124,7 +124,7 @@ impl Config {
             no_build_target: false,
             verbose_cmake: false,
             verbose_make: false,
-            pic: None
+            pic: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub struct Config {
     no_build_target: bool,
     verbose_cmake: bool,
     verbose_make: bool,
+    pic: Option<bool>
 }
 
 /// Builds the native library rooted at `path` with the default cmake options.
@@ -123,7 +124,14 @@ impl Config {
             no_build_target: false,
             verbose_cmake: false,
             verbose_make: false,
+            pic: None
         }
+    }
+
+    /// Sets flag for PIC. Otherwise use cc::Build platform default
+    pub fn pic(&mut self, explicit_flag: bool) -> &mut Config {
+        self.pic = Some(explicit_flag);
+        self
     }
 
     /// Sets the build-tool generator (`-G`) for this compilation.
@@ -344,6 +352,10 @@ impl Config {
         if let Some(static_crt) = self.static_crt {
             c_cfg.static_crt(static_crt);
             cxx_cfg.static_crt(static_crt);
+        }
+        if let Some(explicit_flag) = self.pic {
+            c_cfg.static_crt(explicit_flag);
+            cxx_cfg.static_crt(explicit_flag);
         }
         let c_compiler = c_cfg.get_compiler();
         let cxx_compiler = cxx_cfg.get_compiler();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,8 +354,8 @@ impl Config {
             cxx_cfg.static_crt(static_crt);
         }
         if let Some(explicit_flag) = self.pic {
-            c_cfg.static_crt(explicit_flag);
-            cxx_cfg.static_crt(explicit_flag);
+            c_cfg.pic(explicit_flag);
+            cxx_cfg.pic(explicit_flag);
         }
         let c_compiler = c_cfg.get_compiler();
         let cxx_compiler = cxx_cfg.get_compiler();


### PR DESCRIPTION
I had trouble using cmake-rs to make a library that I was linking to from an embedded project, where [it's standard practice to not have a global offset table](https://github.com/rust-embedded/cortex-m-rt/blob/master/link.x.in#L204-L209).

As suggested in the link above, setting Build.pic value to the right thing solves the issue, but I couldn't find out how to override it with the current API.
