### PR TITLE
Create constructor allowing user to set c_cfg and cxx_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,9 +108,13 @@ impl Config {
         Config::new_with_configs(path, None, None)
     }
 
-        /// Creates a new blank set of configuration to build the project specified
+    /// Creates a new blank set of configuration to build the project specified
     /// at the path `path`.
-    pub fn new_with_configs<P: AsRef<Path>>(path: P, c_cfg: Option<cc::Build>, cxx_cfg: Option<cc::Build>) -> Config {
+    pub fn new_with_configs<P: AsRef<Path>>(
+        path: P,
+        c_cfg: Option<cc::Build>,
+        cxx_cfg: Option<cc::Build>,
+    ) -> Config {
         Config {
             path: env::current_dir().unwrap().join(path),
             generator: None,


### PR DESCRIPTION
[In a previous PR](https://github.com/alexcrichton/cmake-rs/pull/89), an extra Config field and a setter for that field were created.

Perhaps letting the user pass `c_cfg` and/or `cxx_cfg` would allow more flexible usage? Otherwise, every "useful" configuration field could potentially be made into a field and a setter.