### PR TITLE
Cmake restart fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,16 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+    - name: Check versions
+      run: |
+          set -e
+          cargo --version
+          rustc --version
+          cmake --version
+          gcc --version
+          clang --version
+          echo "end of versions checking"
+      shell: bash
     - run: cargo test
 
   rustfmt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ categories = ["development-tools::build-utils"]
 
 [dependencies]
 cc = "1.0.41"
+
+[dev-dependencies]
+tempfile = "3.1.0"
+

--- a/tests/handling_reset_cache_after_set_var.rs
+++ b/tests/handling_reset_cache_after_set_var.rs
@@ -1,0 +1,68 @@
+extern crate tempfile;
+
+use std::{env, error::Error, fs, path::Path};
+
+#[test]
+fn handling_reset_cache_after_set_var() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+
+    fill_dir(tmp_dir.path()).unwrap();
+
+    if cfg!(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        target_vendor = "unknown"
+    )) {
+        env::set_var("TARGET", "x86_64-unknown-linux-gnu");
+        env::set_var("HOST", "x86_64-unknown-linux-gnu");
+        env::set_var("OUT_DIR", tmp_dir.path());
+        env::set_var("PROFILE", "debug");
+        env::set_var("OPT_LEVEL", "0");
+        env::set_var("DEBUG", "true");
+        let dst = cmake::Config::new(tmp_dir.path())
+            .define("OPT1", "False")
+            .build_target("all")
+            .build()
+            .join("build");
+
+        assert!(fs::read_to_string(dst.join("CMakeCache.txt"))
+            .unwrap()
+            .contains("OPT1:BOOL=False"));
+        env::set_var("CC", "clang");
+        env::set_var("CXX", "clang++");
+        let dst = cmake::Config::new(tmp_dir.path())
+            .define("OPT1", "False")
+            .build_target("all")
+            .build()
+            .join("build");
+
+        assert!(fs::read_to_string(dst.join("CMakeCache.txt"))
+            .unwrap()
+            .contains("OPT1:BOOL=False"));
+    }
+}
+
+fn fill_dir(tmp_dir: &Path) -> Result<(), Box<dyn Error>> {
+    fs::write(
+        tmp_dir.join("CMakeLists.txt"),
+        r#"
+project(xyz)
+cmake_minimum_required(VERSION 3.9)
+
+option(OPT1 "some option" ON)
+add_executable(xyz main.cpp)
+"#,
+    )?;
+    fs::write(
+        tmp_dir.join("main.cpp"),
+        r#"
+#include <cstdio>
+#define DO_STRINGIFY(x) #x
+#define STRINGIFY(x) DO_STRINGIFY(x)
+int main() {
+	printf("option: %s\n", STRINGIFY(OPT1));
+}
+"#,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
The problem is frequent for me on macOS, because of I run `cargo` directly and
 `cargo` indirectly via `xcodebuild`. In the first case `cmake` detects `CC` as `/usr/bin/clang`
in the second as `/Applications/Xcode.app/.../usr/bin/clang`. It is actually the same clang,
but this case cmake cache reset, and build failure.

fix #97