### PR TITLE
Cmake restart fix v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,16 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+    - name: Check versions
+      run: |
+          set -e
+          cargo --version
+          rustc --version
+          cmake --version
+          gcc --version
+          clang --version
+          echo "end of versions checking"
+      shell: bash
     - run: cargo test
 
   rustfmt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ categories = ["development-tools::build-utils"]
 
 [dependencies]
 cc = "1.0.41"
+
+[dev-dependencies]
+tempfile = "3.1.0"
+

--- a/tests/handling_reset_cache_after_set_var.rs
+++ b/tests/handling_reset_cache_after_set_var.rs
@@ -1,0 +1,68 @@
+extern crate tempfile;
+
+use std::{env, error::Error, fs, path::Path};
+
+#[test]
+fn handling_reset_cache_after_set_var() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+
+    fill_dir(tmp_dir.path()).unwrap();
+
+    if cfg!(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        target_vendor = "unknown"
+    )) {
+        env::set_var("TARGET", "x86_64-unknown-linux-gnu");
+        env::set_var("HOST", "x86_64-unknown-linux-gnu");
+        env::set_var("OUT_DIR", tmp_dir.path());
+        env::set_var("PROFILE", "debug");
+        env::set_var("OPT_LEVEL", "0");
+        env::set_var("DEBUG", "true");
+        let dst = cmake::Config::new(tmp_dir.path())
+            .define("OPT1", "False")
+            .build_target("all")
+            .build()
+            .join("build");
+
+        assert!(fs::read_to_string(dst.join("CMakeCache.txt"))
+            .unwrap()
+            .contains("OPT1:BOOL=False"));
+        env::set_var("CC", "clang");
+        env::set_var("CXX", "clang++");
+        let dst = cmake::Config::new(tmp_dir.path())
+            .define("OPT1", "False")
+            .build_target("all")
+            .build()
+            .join("build");
+
+        assert!(fs::read_to_string(dst.join("CMakeCache.txt"))
+            .unwrap()
+            .contains("OPT1:BOOL=False"));
+    }
+}
+
+fn fill_dir(tmp_dir: &Path) -> Result<(), Box<dyn Error>> {
+    fs::write(
+        tmp_dir.join("CMakeLists.txt"),
+        r#"
+project(xyz)
+cmake_minimum_required(VERSION 3.9)
+
+option(OPT1 "some option" ON)
+add_executable(xyz main.cpp)
+"#,
+    )?;
+    fs::write(
+        tmp_dir.join("main.cpp"),
+        r#"
+#include <cstdio>
+#define DO_STRINGIFY(x) #x
+#define STRINGIFY(x) DO_STRINGIFY(x)
+int main() {
+	printf("option: %s\n", STRINGIFY(OPT1));
+}
+"#,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
Extracted from comments that I add to cmake-rs:

// Acording to
// https://gitlab.kitware.com/cmake/cmake/-/issues/18959
// CMake does not support usage of the same build directory for different
// compilers. The problem is that we can not make sure that we use the same compiler
// before running of CMake without CMake's logic duplication (for example consider
// usage of CMAKE_TOOLCHAIN_FILE). Fortunately for us, CMake can detect is
// compiler changed by itself. This is done for interactive CMake's configuration,
// like ccmake/cmake-gui. But after compiler change CMake resets all cached variables.
// So

run cmake twice with parameters specified by user of `cmake-rs` to make sure that
settings not disappear. Tested on macOS during several weeks. As I found out the problem that I faced in #98 ,
is unrelated to this patch, and related to alexcrichton/cc-rs#530 , but I made little changes of the implementation
to make it more robust. 