### PR TITLE
Fix apparent typo in source of CXX configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,7 @@ impl Config {
         if !ndk {
             c_cfg.target(&target);
         }
-        let mut cxx_cfg = self.c_cfg.clone().unwrap_or_default();
+        let mut cxx_cfg = self.cxx_cfg.clone().unwrap_or_default();
         cxx_cfg
             .cargo_metadata(false)
             .cpp(true)


### PR DESCRIPTION
I noticed this while doing my other PR, and got a compiler warning that this field  (`cxx_cfg`) was unused. It looks to me like the code accidentally reads `c_cfg` instead, probably due to a copy/paste mistake. I'm not 100% sure that this wasn't intentional, but if it was, there is some dead code that can be removed instead.