### PR TITLE
Allow per-target cmake toolchain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,7 @@ impl Config {
         };
         let host = self.host.clone().unwrap_or_else(|| getenv_unwrap("HOST"));
 
-        let mut generator = self
+        let generator = self
             .generator
             .clone()
             .or_else(|| get_target_env_var(&host, &target, "CMAKE_GENERATOR"));
@@ -840,7 +840,7 @@ impl Config {
                  doesn't know how to generate cmake files for it, \
                  can the `cmake` crate be updated?"
             ),
-            Err(msg) => panic!(msg),
+            Err(msg) => panic!("{}", msg),
         };
         if ["i686", "x86_64", "thumbv7a", "aarch64"]
             .iter()


### PR DESCRIPTION
This would help cross-compilation a bit, allowing the user to have some global environment variables set up for each of their cross-compilation toolchain.

The `get_target_env_var` function is taken from `cc-rs::get_var` function.