### PR TITLE
[alexcrichton/cmake-rs#122] Refactor setting the number of parallel jobs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,6 +802,8 @@ impl Config {
         // And build!
         let target = self.cmake_target.clone().unwrap_or("install".to_string());
         let mut cmd = Command::new(&executable);
+        cmd.current_dir(&build);
+
         for &(ref k, ref v) in c_compiler.env().iter().chain(&self.env) {
             cmd.env(k, v);
         }
@@ -816,11 +818,11 @@ impl Config {
             cmd.arg("--target").arg(target);
         }
 
-        cmd.arg("--config")
-            .arg(&profile)
-            .arg("--")
-            .args(&self.build_args)
-            .current_dir(&build);
+        cmd.arg("--config").arg(&profile);
+
+        if !&self.build_args.is_empty() {
+            cmd.arg("--").args(&self.build_args);
+        }
 
         if let Some(flags) = parallel_flags {
             cmd.arg(flags);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ impl Config {
 
         if let Ok(s) = env::var("NUM_JOBS") {
             // See https://cmake.org/cmake/help/v3.12/manual/cmake.1.html#build-tool-mode
-            cmd.arg("--parallel").arg(s)
+            cmd.arg("--parallel").arg(s);
         }
 
         if !&self.build_args.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -760,45 +760,6 @@ impl Config {
             println!("CMake project was already configured. Skipping configuration step.");
         }
 
-        let mut makeflags = None;
-        let mut parallel_flags = None;
-
-        if let Ok(s) = env::var("NUM_JOBS") {
-            match generator.as_ref().map(|g| g.to_string_lossy()) {
-                Some(ref g) if g.contains("Ninja") => {
-                    parallel_flags = Some(format!("-j{}", s));
-                }
-                Some(ref g) if g.contains("Visual Studio") => {
-                    parallel_flags = Some(format!("/MP{}", s));
-                }
-                Some(ref g) if g.contains("NMake") => {
-                    // NMake creates `Makefile`s, but doesn't understand `-jN`.
-                }
-                _ if fs::metadata(&build.join("Makefile")).is_ok() => {
-                    match env::var_os("CARGO_MAKEFLAGS") {
-                        // Only do this on non-windows and non-bsd
-                        // On Windows, we could be invoking make instead of
-                        // mingw32-make which doesn't work with our jobserver
-                        // bsdmake also does not work with our job server
-                        Some(ref s)
-                            if !(cfg!(windows)
-                                || cfg!(target_os = "openbsd")
-                                || cfg!(target_os = "netbsd")
-                                || cfg!(target_os = "freebsd")
-                                || cfg!(target_os = "bitrig")
-                                || cfg!(target_os = "dragonflybsd")) =>
-                        {
-                            makeflags = Some(s.clone())
-                        }
-
-                        // This looks like `make`, let's hope it understands `-jN`.
-                        _ => makeflags = Some(OsString::from(format!("-j{}", s))),
-                    }
-                }
-                _ => {}
-            }
-        }
-
         // And build!
         let target = self.cmake_target.clone().unwrap_or("install".to_string());
         let mut cmd = Command::new(&executable);
@@ -806,10 +767,6 @@ impl Config {
 
         for &(ref k, ref v) in c_compiler.env().iter().chain(&self.env) {
             cmd.env(k, v);
-        }
-
-        if let Some(flags) = makeflags {
-            cmd.env("MAKEFLAGS", flags);
         }
 
         cmd.arg("--build").arg(".");
@@ -820,12 +777,13 @@ impl Config {
 
         cmd.arg("--config").arg(&profile);
 
-        if !&self.build_args.is_empty() {
-            cmd.arg("--").args(&self.build_args);
+        if let Ok(s) = env::var("NUM_JOBS") {
+            // See https://cmake.org/cmake/help/v3.12/manual/cmake.1.html#build-tool-mode
+            cmd.arg("--parallel").arg(s)
         }
 
-        if let Some(flags) = parallel_flags {
-            cmd.arg(flags);
+        if !&self.build_args.is_empty() {
+            cmd.arg("--").args(&self.build_args);
         }
 
         run(&mut cmd, "cmake");


### PR DESCRIPTION
CMake 3.12 (released in 2018) supports `--parallel <jobs>` (see https://cmake.org/cmake/help/v3.12/manual/cmake.1.html#build-tool-mode). It significantly simplifies the configuration of parallel jobs. The current solution assumes that when the generator is `Visual Studio`  the correct flag is `/MP{n}`, however, it is possible that the underlying build tool is `MSBuild` for which this flag is invalid.
This PR makes use of CMake's `--parallel` flag.

Resolves https://github.com/alexcrichton/cmake-rs/issues/122