### PR TITLE
Define `CMAKE_SYSTEM_NAME` when compiling for Linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,6 +637,10 @@ impl Config {
                 cmd.arg("-DCMAKE_OSX_SYSROOT=/");
                 cmd.arg("-DCMAKE_OSX_DEPLOYMENT_TARGET=");
             }
+        } else if target.contains("linux") {
+            if !self.defined("CMAKE_SYSTEM_NAME") {
+                cmd.arg("-DCMAKE_SYSTEM_NAME=Linux");
+            }
         }
         if let Some(ref generator) = generator {
             cmd.arg("-G").arg(generator);


### PR DESCRIPTION
The default value of `CMAKE_SYSTEM_NAME` is [`CMAKE_HOST_SYSTEM_NAME`](https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_NAME.html#variable:CMAKE_HOST_SYSTEM_NAME) so when cross compiling from macOS to Linux cmake gets confused.

The motivation of this PR is to fix an issue posted on reddit: https://www.reddit.com/r/rust/comments/r60fzb/m1_users_how_are_you_cross_compiling/ , by define `CMAKE_SYSTEM_NAME`, [audiopus_sys](https://github.com/Lakelezz/audiopus_sys) can be easily cross compiled once you have target cross compiler setup.

Helps with #80 