### PR TITLE
Don't set CMAKE_SYSTEM_NAME=Linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,10 +637,6 @@ impl Config {
                 cmd.arg("-DCMAKE_OSX_SYSROOT=/");
                 cmd.arg("-DCMAKE_OSX_DEPLOYMENT_TARGET=");
             }
-        } else if target.contains("linux") {
-            if !self.defined("CMAKE_SYSTEM_NAME") {
-                cmd.arg("-DCMAKE_SYSTEM_NAME=Linux");
-            }
         }
         if let Some(ref generator) = generator {
             cmd.arg("-G").arg(generator);


### PR DESCRIPTION
Previously, this would set SYSTEM_NAME unconditionally whenever targeting Linux.
Unfortunately, Cmake unsets some other variables when SYSTEM_NAME is set;
in particular `CMAKE_SYSTEM_VERSION` and `CMAKE_SYSTEM_PROCESSOR`.

To avoid regressing other builds, this reverts the change; builds which
want to cross-compile to linux can set `SYSTEM_NAME` themselves.

Fixes https://github.com/alexcrichton/cmake-rs/issues/138 (I confirmed locally that this fixes the build for boring-sys).