### PR TITLE
fix clippy warning and upgrade to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = """
 A build dependency for running `cmake` to build a native library
 """
 categories = ["development-tools::build-utils"]
+edition = "2021"
 
 [dependencies]
 cc = "1.0.72"


### PR DESCRIPTION
fix clippy warning and upgrade to edition 2021