### PR TITLE
Add Visual Studio 2026 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-cc = "1.1.0"
+cc = "1.2.46"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -960,6 +960,7 @@ impl Config {
         use cc::windows_registry::{find_vs_version, VsVers};
 
         let base = match find_vs_version() {
+            Ok(VsVers::Vs18) => "Visual Studio 18 2026",
             Ok(VsVers::Vs17) => "Visual Studio 17 2022",
             Ok(VsVers::Vs16) => "Visual Studio 16 2019",
             Ok(VsVers::Vs15) => "Visual Studio 15 2017",


### PR DESCRIPTION
I have tested this and it appears to work well.

Fixes https://github.com/rust-lang/cmake-rs/issues/253