### PR TITLE
Pass ANDROID_ABI and ANDROID_PLATFORM environment variables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,6 +507,15 @@ impl Config {
             }
         }
 
+        // These environment variables are set by cargo-ndk when compiling for
+        // Android (since version 4.x).
+        if let Ok(abi) = env::var("ANDROID_ABI") {
+            self.define("ANDROID_ABI", abi);
+        }
+        if let Ok(platform) = env::var("ANDROID_PLATFORM") {
+            self.define("ANDROID_PLATFORM", platform);
+        }
+
         let generator = self
             .generator
             .clone()


### PR DESCRIPTION
Uses environment variables as passed by cargo-ndk version 4.0 and later, and passes them as defines to cmake. Note the environment variable names as currently documented on <https://crates.io/crates/cargo-ndk> are outdated, the docs have been fixed later in <https://github.com/bbqsrc/cargo-ndk/commit/1bee04b305>.

For me this fixed issues with cross compilation to android, similar to #226.

I wasn't quite sure where to put this logic, so please let me know if you want it moved somewhere more appropriate.