### PR TITLE
cmake -B only for v3.13 and later

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,7 +586,9 @@ impl Config {
 
         cmd.arg(&self.path).current_dir(&build_dir);
 
-        cmd.arg("-B").arg(&build_dir);
+        if version >= Version::new(3, 13) {
+            cmd.arg("-B").arg(&build_dir);
+        }
 
         let mut is_ninja = false;
         if let Some(ref generator) = generator {


### PR DESCRIPTION
### Issues:
Addresses: #261 

### Description
The `-B` CLI option for cmake was introduced in [v3.13](https://cmake.org/cmake/help/v3.13/manual/cmake.1.html#cmdoption-cmake-B), but is not available in [v3.12](https://cmake.org/cmake/help/v3.12/manual/cmake.1.html) or earlier.

### Testing

I built cmake v3.5 locally, and verified that this change fixes the build failure we were experiencing.
```
...
   Compiling cmake v0.1.55 (/home/justsmth/repos/cmake-rs)
   Compiling aws-lc-sys v0.34.0 (/home/justsmth/repos/aws-lc-rs/aws-lc-sys)
warning: aws-lc-sys@0.34.0: Environment Variable found 'AWS_LC_SYS_CMAKE_BUILDER': '1'
warning: aws-lc-sys@0.34.0: Value: 1 is true.
warning: aws-lc-sys@0.34.0: Emitting configuration: cargo:rustc-cfg=x86_64_unknown_linux_gnu
warning: aws-lc-sys@0.34.0: Environment Variable found 'CMAKE': '/home/justsmth/cmake-3.5/bin/cmake'
warning: aws-lc-sys@0.34.0: CMAKE environment variable set: /home/justsmth/cmake-3.5/bin/cmake
warning: aws-lc-sys@0.34.0: Building with: CMake
warning: aws-lc-sys@0.34.0: Symbol Prefix: Some("aws_lc_0_34_0")
warning: aws-lc-sys@0.34.0: Environment Variable found 'CMAKE': '/home/justsmth/cmake-3.5/bin/cmake'
warning: aws-lc-sys@0.34.0: CMAKE environment variable set: /home/justsmth/cmake-3.5/bin/cmake
warning: aws-lc-sys@0.34.0: Target platform: 'x86_64-unknown-linux-gnu'
warning: aws-lc-sys@0.34.0: Compilation of 'c11.c' succeeded - Ok(["/home/justsmth/repos/aws-lc-rs/target/debug/build/aws-lc-sys-a6f8ef1634cae444/out/out-c11/7dfda64fdf5a526c-c11.o"]).
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.08s
```